### PR TITLE
class for MagRepack function has been removed

### DIFF
--- a/functions.hpp
+++ b/functions.hpp
@@ -149,7 +149,7 @@ class CfgFunctions {
 			class playerEventHandlers {};
 			class prepareRappel {};
 			class prompt {};
-			class repackMagazines {};
+			// class repackMagazines {};
 			class resetVehicle {};
 			class restrictedArea {};
 			class revive {};


### PR DESCRIPTION
A memory leak was found in the Repack Magazine Script has been commented out untill a better fix can be introduced
or the memory leak can be fixed